### PR TITLE
[EuiSelectable]: onSearch returns visibleOptions

### DIFF
--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -53,7 +53,16 @@ type EuiSelectableSearchableProps<T> = ExclusiveUnion<
     /**
      * Passes props down to the `EuiFieldSearch`
      */
-    searchProps?: Partial<EuiSelectableSearchProps<T>>;
+    searchProps?: EuiSelectableSearchableSearchProps<T>;
+  }
+>;
+
+type EuiSelectableSearchableSearchProps<T> = Partial<
+  Omit<EuiSelectableSearchProps<T>, 'onSearch'> & {
+    onSearch: (
+      searchValue: string,
+      matchingOptions: Array<EuiSelectableOption<T>>
+    ) => void;
   }
 >;
 
@@ -337,7 +346,7 @@ export class EuiSelectable<T = {}> extends Component<
       }
     );
     if (this.props.searchProps && this.props.searchProps.onSearch) {
-      this.props.searchProps.onSearch(searchValue);
+      this.props.searchProps.onSearch(searchValue, visibleOptions);
     }
   };
 
@@ -524,7 +533,7 @@ export class EuiSelectable<T = {}> extends Component<
      */
     const getAccessibleName = (
       props:
-        | Partial<EuiSelectableSearchProps<T>>
+        | EuiSelectableSearchableSearchProps<T>
         | EuiSelectableOptionsListPropsWithDefaults
         | undefined,
       messageContentId?: string


### PR DESCRIPTION
### Summary

Closes #5165

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
